### PR TITLE
Add use enabled option

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -13,7 +13,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each, type: :request) do |example|
-    if response ||= last_response
+    if RspecApiBlueprint.configuration.enabled && response ||= last_response
       request ||= last_request
 
       RspecApiBlueprint.record example, request, response


### PR DESCRIPTION
### Overview
Changed to use enabled option.

### Description
I am very grateful that documents will be created automatically. However, there are cases where it is not pleasing to update the document every time RSpec is always executed.
For example, when the update date and time is returned to the response JSON, the document is always changed. Differences always occur when managing documents with git.

Therefore, it was used for controlling document output using an unused option.
